### PR TITLE
support custom registry zip url and bump version to 0.1.61

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@serverless-devs/core",
-  "version": "0.1.60",
+  "version": "0.1.61",
   "description": "Serverless Devs Tool Core Component",
   "keywords": [
     "Serverless",

--- a/publish.yaml
+++ b/publish.yaml
@@ -2,7 +2,7 @@ Type: Component
 Name: core
 Provider:
   - 阿里云
-Version: 0.1.60
+Version: 0.1.61
 Description: Serverless Devs 核心组件
 HomePage: https://github.com/Serverless-Devs/core
 Tags: #标签详情

--- a/src/common/load/loadApplication.ts
+++ b/src/common/load/loadApplication.ts
@@ -70,10 +70,11 @@ class LoadApplication {
   async byUrl() {
     const { source, registry, target } = this.config;
     const applicationPath = path.resolve(target, source);
-    await downloadRequest(registry, applicationPath, {
-      extract: true,
+    return this.handleDecompressFile({
+      zipball_url: registry,
+      applicationPath,
+      name: this.config.name,
     });
-    return applicationPath;
   }
   async loadType() {
     const { registry } = this.config;

--- a/src/daemon/constant.js
+++ b/src/daemon/constant.js
@@ -1,3 +1,3 @@
 module.exports = {
-  DEFAULT_CORE_VERSION: '0.1.60',
+  DEFAULT_CORE_VERSION: '0.1.61',
 };


### PR DESCRIPTION
If the business has its own file repository, you can upload the custom application template zip file to the file repository, and you can use the application template initialization as long as you specify the address of the application template zip file through the registry.

eg.

```bash
s init start-fc-demo -r https://private-file-repo.com/start-fc-demo/0.0.1.zip
```