### PR TITLE
support local registry zip

### DIFF
--- a/src/common/downloadRequest.ts
+++ b/src/common/downloadRequest.ts
@@ -35,10 +35,17 @@ async function download(url: string, dest: string, options: IOptions = {}) {
     if (!url.toLocaleLowerCase().startsWith('http')) {
       // local file
       let spin: Ora;
-      const filePath = path.join(dest, filename);
+
       fs.mkdirpSync(dest);
-      fs.copyFileSync(url, filePath);
-      return resolve({ filePath: filePath, spin: spin });
+      if (url.endsWith('.zip')) {
+        const filePath = path.join(dest, filename);
+        fs.copyFileSync(url, filePath);
+        return resolve({ filePath: filePath, spin: spin });
+      } else {
+        // copy dir to dest dir
+        fs.copySync(url, dest);
+        return resolve({ filePath: dest, spin: spin });
+      }
     }
 
     const pkg = url.toLowerCase().startsWith('https:') ? https : http;
@@ -97,6 +104,9 @@ export default async (url: string, dest: string, options: IOptions = {}) => {
   const { extract, filename, ...restOpts } = options;
   try {
     const { filePath, spin } = await download(url, dest, options);
+    if (filePath == dest) {
+      return;
+    }
     if (extract) {
       let timer;
       let num = 0;

--- a/src/common/downloadRequest.ts
+++ b/src/common/downloadRequest.ts
@@ -29,9 +29,20 @@ export interface IOptions extends DecompressOptions {
 
 async function download(url: string, dest: string, options: IOptions = {}) {
   const { filename = 'demo.zip' } = options;
-  const uri = new URL(url);
-  const pkg = url.toLowerCase().startsWith('https:') ? https : http;
+  
+  
   return await new Promise<{ filePath: string; spin: Ora }>((resolve, reject) => {
+    if (!url.toLocaleLowerCase().startsWith('http')) {
+      // local file
+      let spin: Ora;
+      const filePath = path.join(dest, filename);
+      fs.mkdirpSync(dest);
+      fs.copyFileSync(url, filePath);
+      return resolve({ filePath: filePath, spin: spin });
+    }
+
+    const pkg = url.toLowerCase().startsWith('https:') ? https : http;
+    const uri = new URL(url);
     pkg.get(uri.href).on('response', (res) => {
       const len = parseInt(res.headers['content-length'], 10);
       fs.ensureDirSync(dest);


### PR DESCRIPTION
support init from local registry zip

This way, you can use a Git repository as a private file repository to maintain application templates in a private repository. When someone needs to initialize a template, they can first use "git pull" to retrieve the template from the file repository, and then use this feature to initialize the function application from the local file template.

At the same time, this feature is also very convenient for template testing. You can quickly test with a local directory or a local file template archive.

For example: 

```bash
# init from local function template zip
s init -r ~/private-git-repo/function-template.zip

# init from local function template dir
s init -r ~/private-git-repo/function-template/
```