### PR TITLE
supoort local registry

### DIFF
--- a/src/common/downloadRequest.ts
+++ b/src/common/downloadRequest.ts
@@ -105,6 +105,7 @@ export default async (url: string, dest: string, options: IOptions = {}) => {
   try {
     const { filePath, spin } = await download(url, dest, options);
     if (filePath == dest) {
+      // init from local registry dir
       return;
     }
     if (extract) {


### PR DESCRIPTION
Support init function from local registry
This way, you can use a Git repository as a private file repository to maintain application templates in a private repository. When a business needs to initialize a template, they can first use "git pull" to retrieve the template from the file repository, and then use this feature to initialize the function application from the local file template.

At the same time, this feature is also very convenient for template testing. You can quickly test with a local directory or a local file template archive.

For example: 

```bash
# init from local registry zip
s init -r ~/private-git-repo/function-template.zip


# init from local registry dir
s init -r ~/private-git-repo/function-template

```